### PR TITLE
patch(types): thread handling

### DIFF
--- a/src/structures/Webhook.ts
+++ b/src/structures/Webhook.ts
@@ -200,6 +200,7 @@ export class Webhook extends EventEmitter {
     if (!options.content && !options.embeds && !options.files)
       throw new Error("No content, embeds or files");
 
+    // @ts-expect-error
     if (options.threadID && options.thread_name)
       throw new Error(
         "Cannot create a thread (thread_name) and send to an existing one (threadID)."
@@ -233,6 +234,7 @@ export class Webhook extends EventEmitter {
         flags: options.flags,
         tts: options.tts,
         username: options.username,
+        // @ts-expect-error
         thread_name: options.thread_name,
       },
       options.files

--- a/src/util/types.message.ts
+++ b/src/util/types.message.ts
@@ -29,7 +29,7 @@ export type MessageData = {
 export type MessageOptions = EditMessageOptions &
   RequiredMessageOptionsUnion &
   Partial<PartialWebhookMessageOptions> &
-  Partial<ThreadLikeTarget | { thread_name: string }>;
+  Partial<ThreadLikeTarget | { thread_name?: string }>;
 
 export type EditMessageOptions = Partial<BaseMessageOptions>;
 

--- a/src/util/types.message.ts
+++ b/src/util/types.message.ts
@@ -55,7 +55,7 @@ export type SharedMessageData = {
 /** A series of fields for a message, one of which must be filled out. */
 export type RequiredMessageOptionsUnion =
   | { content: string }
-  | { embeds: Embed[] }
+  | { embeds: EmbedOptions[] }
   | { files: FileAttachment[] };
 
 /**

--- a/src/util/types.message.ts
+++ b/src/util/types.message.ts
@@ -28,19 +28,18 @@ export type MessageData = {
 
 export type MessageOptions = EditMessageOptions &
   RequiredMessageOptionsUnion &
-  PartialWebhookMessageOptions &
-  Partial<ThreadLikeTarget | { threadName: string }>;
+  Partial<PartialWebhookMessageOptions> &
+  Partial<ThreadLikeTarget | { thread_name: string }>;
 
-export type EditMessageOptions = Partial<BaseMessageOptions & ThreadLikeTarget>;
+export type EditMessageOptions = Partial<BaseMessageOptions>;
 
 export type BaseMessageOptions = {
   allowed_mentions: Partial<AllowedMentions>;
   embeds: EmbedOptions[];
   files: FileAttachment[];
   suppressEmbeds?: boolean;
-  threadID?: string;
-  thread_name?: string;
-} & SharedMessageData;
+} & SharedMessageData &
+  Partial<ThreadLikeTarget>;
 
 export type ThreadLikeTarget = { threadID: string };
 


### PR DESCRIPTION
There are a few workarounds that I would have opted to not use, but it works for now so that's as good as it gets.

* `threadID` and `thread_name` are the source of truth. _`threadName` was a dummy prop, not used at all._
* `RequiredMessageOptionsUnion|?~embeds` - `Embed[]` -> `EmbedOptions[]`
* `@ts-expect-error` has been used where raw validations are necessary to avoid code 400s from Discord... and to actually use the prop itself when it's able.
  > As it stands, Discord only describes this error at the very end of their [Error Codes table](https://discord.com/developers/docs/topics/opcodes-and-status-codes#json-json-error-codes) - that is the only mention of it, despite being a mutually exclusive pair.
  > ```json
  > {
  >   "message": "Webhooks posted to forum channels cannot have both thread_name and thread_id",
  >   "code": 220002
  > }
  > ```